### PR TITLE
Convert Material.{Ambient,Diffuse,Specular} from float64 to Color.

### DIFF
--- a/examples/animation.go
+++ b/examples/animation.go
@@ -12,7 +12,7 @@ func RunAnimation(printProgress bool, jobs int) {
 	midSphere := NewSphere()
 	midSphere.SetTransform(NewTranslation(-0.5, 1, 0.5))
 	midSphere.Material.Reflective = 1.0
-	midSphere.Material.Diffuse = 0.1
+	midSphere.Material.Diffuse = NewColor(0.1, 0.1, 0.1)
 	midSphere.Material.Color = NewColor(0.75, 0.75, 0.75)
 
 	rightSphere := NewSphere()
@@ -57,7 +57,7 @@ func RunAnimation(printProgress bool, jobs int) {
 			floor.Material.Pattern = NewCheckerPattern(Colors["Black"], Colors["White"])
 
 			rightWall := NewPlane()
-			rightWall.Material.Ambient = 0.5
+			rightWall.Material.Ambient = NewColor(0.5, 0.5, 0.5)
 			rightWall.Material.Reflective = 0.5
 			rightWall.SetTransform(rightWall.Transform.Multiply(NewTranslation(0, 0, 5)))
 			rightWall.SetTransform(rightWall.Transform.Multiply(NewRotateY(math.Pi / 4)))
@@ -65,7 +65,7 @@ func RunAnimation(printProgress bool, jobs int) {
 			rightWall.Material.Pattern = NewCheckerPattern(Colors["Blue"], Colors["Green"])
 
 			leftWall := NewPlane()
-			leftWall.Material.Ambient = 0.5
+			leftWall.Material.Ambient = NewColor(0.5, 0.5, 0.5)
 			leftWall.Material.Reflective = 0.2
 			leftWall.SetTransform(leftWall.Transform.Multiply(NewTranslation(0, 0, 5)))
 			leftWall.SetTransform(leftWall.Transform.Multiply(NewRotateY(-math.Pi / 4)))

--- a/examples/draw_skybox.go
+++ b/examples/draw_skybox.go
@@ -46,20 +46,20 @@ func RunDrawSkybox(printProgress bool, jobs int) {
 			getCubeSide("tmp/LancellotiChapel/posy.ppm"), // u
 			getCubeSide("tmp/LancellotiChapel/negy.ppm"), // d
 		)
-		cube.Material.Ambient = 1.0
-		cube.Material.Specular = 0
-		cube.Material.Diffuse = 0
+		cube.Material.Ambient = NewColor(1.0, 1.0, 1.0)
+		cube.Material.Specular = NewColor(0, 0, 0)
+		cube.Material.Diffuse = NewColor(0, 0, 0)
 
 		sphere := NewSphere()
 		sphere.SetTransform(sphere.Transform.Compose(
 			NewUScale(0.75),
 			NewTranslation(0, 0, 5),
 		))
-		sphere.Material.Diffuse = 0.4
-		sphere.Material.Specular = 0.6
+		sphere.Material.Diffuse = NewColor(0.4, 0.4, 0.4)
+		sphere.Material.Specular = NewColor(0.6, 0.6, 0.6)
 		sphere.Material.Shininess = 20
 		sphere.Material.Reflective = .6
-		sphere.Material.Ambient = 0
+		sphere.Material.Ambient = NewColor(0, 0, 0)
 
 		world.Objects = []*Shape{
 			cube,

--- a/examples/draw_uv_align_check.go
+++ b/examples/draw_uv_align_check.go
@@ -19,8 +19,8 @@ func RunDrawUVAlignCheck(printProgress bool, jobs int) {
 		))
 
 		floor := NewPlane()
-		floor.Material.Ambient = 0.1
-		floor.Material.Diffuse = 0.8
+		floor.Material.Ambient = NewColor(0.1, 0.1, 0.1)
+		floor.Material.Diffuse = NewColor(0.8, 0.8, 0.8)
 		floor.Material.Pattern = NewTextureMapPattern(
 			NewUVAlignCheckPattern(
 				NewColor(1, 1, 1), // white

--- a/examples/draw_uv_align_check_cubes.go
+++ b/examples/draw_uv_align_check_cubes.go
@@ -27,9 +27,9 @@ func RunDrawUVAlignCheckCubes(printProgress bool, jobs int) {
 		NewUVAlignCheckPattern(Colors["Brown"], Colors["Cyan"], Colors["Purple"], Colors["Red"], Colors["Yellow"]),
 		NewUVAlignCheckPattern(Colors["Purple"], Colors["Brown"], Colors["Green"], Colors["Blue"], Colors["White"]),
 	)
-	material.Ambient = 0.2
-	material.Specular = 0
-	material.Diffuse = 0.8
+	material.Ambient = NewColor(0.2, 0.2, 0.2)
+	material.Specular = NewColor(0, 0, 0)
+	material.Diffuse = NewColor(0.8, 0.8, 0.8)
 
 	cube1 := NewCube()
 	cube1.Material = material

--- a/examples/draw_uv_image.go
+++ b/examples/draw_uv_image.go
@@ -16,9 +16,9 @@ func RunDrawUVImage(printProgress bool, jobs int) {
 
 		floor := NewPlane()
 		floor.Material.Color = Colors["White"]
-		floor.Material.Diffuse = 0.1
-		floor.Material.Specular = 0.0
-		floor.Material.Ambient = 0.0
+		floor.Material.Diffuse = NewColor(0.1, 0.1, 0.1)
+		floor.Material.Specular = NewColor(0.0, 0.0, 0.0)
+		floor.Material.Ambient = NewColor(0.0, 0.0, 0.0)
 		floor.Material.Reflective = 0.4
 
 		platform := NewCylinder()
@@ -26,9 +26,9 @@ func RunDrawUVImage(printProgress bool, jobs int) {
 		platform.LocalShape.(*Cylinder).Maximum = 0.1
 		platform.LocalShape.(*Cylinder).Closed = true
 		platform.Material.Color = Colors["White"]
-		platform.Material.Ambient = 0.0
-		platform.Material.Diffuse = 0.2
-		platform.Material.Specular = 0.0
+		platform.Material.Ambient = NewColor(0.0, 0.0, 0.0)
+		platform.Material.Diffuse = NewColor(0.2, 0.2, 0.2)
+		platform.Material.Specular = NewColor(0.0, 0.0, 0.0)
 		platform.Material.Reflective = 0.1
 
 		sphere := NewSphere()
@@ -52,10 +52,10 @@ func RunDrawUVImage(printProgress bool, jobs int) {
 			NewRotateY(1.9),
 			NewTranslation(0, 1.1, 0),
 		))
-		sphere.Material.Diffuse = 0.9
-		sphere.Material.Specular = 0.1
+		sphere.Material.Diffuse = NewColor(0.9, 0.9, 0.9)
+		sphere.Material.Specular = NewColor(0.1, 0.1, 0.1)
 		sphere.Material.Shininess = 10
-		sphere.Material.Ambient = 0.1
+		sphere.Material.Ambient = NewColor(0.1, 0.1, 0.1)
 
 		world.Objects = []*Shape{
 			floor,

--- a/examples/draw_world.go
+++ b/examples/draw_world.go
@@ -21,7 +21,7 @@ func RunDrawWorld(printProgress bool, jobs int) {
 		floor := NewSphere()
 		floor.SetTransform(NewScale(10, 0.01, 10))
 		floor.Material.Color = NewColor(1, 0.9, 0.9)
-		floor.Material.Specular = 0
+		floor.Material.Specular = NewColor(0, 0, 0)
 
 		leftWall := NewSphere()
 		leftWall.SetTransform(NewTranslation(0, 0, 5))
@@ -40,22 +40,22 @@ func RunDrawWorld(printProgress bool, jobs int) {
 		midSphere := NewSphere()
 		midSphere.SetTransform(NewTranslation(-0.5, 1, 0.5))
 		midSphere.Material.Color = NewColor(0.1, 1, 0.5)
-		midSphere.Material.Diffuse = 0.7
-		midSphere.Material.Specular = 0.3
+		midSphere.Material.Diffuse = NewColor(0.7, 0.7, 0.7)
+		midSphere.Material.Specular = NewColor(0.3, 0.3, 0.3)
 
 		rightSphere := NewSphere()
 		rightSphere.SetTransform(NewTranslation(1.5, 0.5, -0.5))
 		rightSphere.SetTransform(rightSphere.Transform.Multiply(NewScale(0.5, 0.5, 0.5)))
 		rightSphere.Material.Color = NewColor(0.5, 1, 0.1)
-		rightSphere.Material.Diffuse = 0.7
-		rightSphere.Material.Specular = 0.3
+		rightSphere.Material.Diffuse = NewColor(0.7, 0.7, 0.7)
+		rightSphere.Material.Specular = NewColor(0.3, 0.3, 0.3)
 
 		leftSphere := NewSphere()
 		leftSphere.SetTransform(NewTranslation(-1.5, 0.33, -0.75))
 		leftSphere.SetTransform(leftSphere.Transform.Multiply(NewScale(0.33, 0.33, 0.33)))
 		leftSphere.Material.Color = NewColor(1, 0.8, 0.1)
-		leftSphere.Material.Diffuse = 0.7
-		leftSphere.Material.Specular = 0.3
+		leftSphere.Material.Diffuse = NewColor(0.7, 0.7, 0.7)
+		leftSphere.Material.Specular = NewColor(0.3, 0.3, 0.3)
 
 		world.Objects = []*Shape{
 			floor,

--- a/examples/draw_world_with_cube.go
+++ b/examples/draw_world_with_cube.go
@@ -20,25 +20,25 @@ func RunDrawWorldWithCube(printProgress bool, jobs int) {
 
 		floor := NewPlane()
 		floor.Material.Color = NewColor(1, 0.9, 0.9)
-		floor.Material.Specular = 0
+		floor.Material.Specular = NewColor(0, 0, 0)
 
 		cubeLeft := NewCube()
 		cubeLeft.SetTransform(NewTranslation(-2, 1, 1))
 		cubeLeft.Material.Color = Colors["Red"]
-		cubeLeft.Material.Diffuse = 0.7
-		cubeLeft.Material.Specular = 0.3
+		cubeLeft.Material.Diffuse = NewColor(0.7, 0.7, 0.7)
+		cubeLeft.Material.Specular = NewColor(0.3, 0.3, 0.3)
 
 		cubeMiddle := NewCube()
 		cubeMiddle.SetTransform(NewTranslation(-0.5, 3, 1))
 		cubeMiddle.Material.Color = Colors["Green"]
-		cubeMiddle.Material.Diffuse = 0.7
-		cubeMiddle.Material.Specular = 0.3
+		cubeMiddle.Material.Diffuse = NewColor(0.7, 0.7, 0.7)
+		cubeMiddle.Material.Specular = NewColor(0.3, 0.3, 0.3)
 
 		cubeRight := NewCube()
 		cubeRight.Material.Color = Colors["Blue"]
 		cubeRight.SetTransform(NewTranslation(1, 1, 1))
-		cubeRight.Material.Diffuse = 0.7
-		cubeRight.Material.Specular = 0.3
+		cubeRight.Material.Diffuse = NewColor(0.7, 0.7, 0.7)
+		cubeRight.Material.Specular = NewColor(0.3, 0.3, 0.3)
 
 		world.Objects = []*Shape{
 			floor,

--- a/examples/draw_world_with_cylinder_and_cone.go
+++ b/examples/draw_world_with_cylinder_and_cone.go
@@ -20,7 +20,7 @@ func RunDrawWorldWithCylinderAndCone(printProgress bool, jobs int) {
 
 		floor := NewPlane()
 		floor.Material.Color = NewColor(1, 0.9, 0.9)
-		floor.Material.Specular = 0
+		floor.Material.Specular = NewColor(0, 0, 0)
 
 		cylinder := NewCylinder()
 		cylinder.LocalShape.(*Cylinder).Closed = true
@@ -28,8 +28,8 @@ func RunDrawWorldWithCylinderAndCone(printProgress bool, jobs int) {
 		cylinder.LocalShape.(*Cylinder).Maximum = 1
 		cylinder.SetTransform(cylinder.Transform.Multiply(NewScale(0.5, 3, 0.5)))
 		cylinder.Material.Color = Colors["Blue"]
-		cylinder.Material.Diffuse = 0.7
-		cylinder.Material.Specular = 0.3
+		cylinder.Material.Diffuse = NewColor(0.7, 0.7, 0.7)
+		cylinder.Material.Specular = NewColor(0.3, 0.3, 0.3)
 
 		cone := NewCone()
 		cone.LocalShape.(*Cone).Closed = true
@@ -39,8 +39,8 @@ func RunDrawWorldWithCylinderAndCone(printProgress bool, jobs int) {
 		cone.SetTransform(cone.Transform.Multiply(NewScale(0.5, 1, 0.5)))
 		cone.SetTransform(cone.Transform.Multiply(NewRotateX(math.Pi)))
 		cone.Material.Color = Colors["Green"]
-		cone.Material.Diffuse = 0.7
-		cone.Material.Specular = 0.3
+		cone.Material.Diffuse = NewColor(0.7, 0.7, 0.7)
+		cone.Material.Specular = NewColor(0.3, 0.3, 0.3)
 
 		iceCreamCone := NewCone()
 		iceCreamCone.LocalShape.(*Cone).Closed = true
@@ -49,8 +49,8 @@ func RunDrawWorldWithCylinderAndCone(printProgress bool, jobs int) {
 		iceCreamCone.SetTransform(iceCreamCone.Transform.Multiply(NewTranslation(-1, 0, -3)))
 		iceCreamCone.SetTransform(iceCreamCone.Transform.Multiply(NewScale(0.5, 2, 0.5)))
 		iceCreamCone.Material.Color = NewColor(0.95, 0.95, 0.85)
-		// iceCreamCone.Material.Diffuse = 0.7
-		// iceCreamCone.Material.Specular = 0.3
+		// iceCreamCone.Material.Diffuse = NewColor(0.7, 0.7, 0.7)
+		// iceCreamCone.Material.Specular = NewColor(0.3, 0.3, 0.3)
 
 		iceCreamScoopOne := NewSphere()
 		iceCreamScoopOne.SetTransform(iceCreamScoopOne.Transform.Multiply(NewTranslation(-1, 2.1, -3)))

--- a/examples/draw_world_with_dice.go
+++ b/examples/draw_world_with_dice.go
@@ -25,8 +25,8 @@ func RunDrawWorldWithDice(printProgress bool, jobs int) {
 		))
 		room.Material.Pattern = NewCheckerPattern(NewColor(1, 1, 1), NewColor(0.9, 0.9, 0.9))
 		room.Material.Pattern.SetTransform(NewUScale(0.05))
-		room.Material.Ambient = 0.1
-		room.Material.Diffuse = 0.7
+		room.Material.Ambient = NewColor(0.1, 0.1, 0.1)
+		room.Material.Diffuse = NewColor(0.7, 0.7, 0.7)
 		room.Material.Reflective = 0.5
 
 		createDice := func(c Color) *Shape {
@@ -36,9 +36,9 @@ func RunDrawWorldWithDice(printProgress bool, jobs int) {
 				NewUScale(1),
 			))
 			cube.Material.Color = c
-			cube.Material.Diffuse = 0.7
-			// cube.Material.Ambient = 0
-			cube.Material.Specular = 0.3
+			cube.Material.Diffuse = NewColor(0.7, 0.7, 0.7)
+			// cube.Material.Ambient = NewColor(0, 0, 0)
+			cube.Material.Specular = NewColor(0.3, 0.3, 0.3)
 			cube.Material.Shininess = 100
 			cube.Material.Reflective = 0.3
 

--- a/examples/draw_world_with_multiple_patterns.go
+++ b/examples/draw_world_with_multiple_patterns.go
@@ -20,22 +20,22 @@ func RunDrawWorldWithMultiplePatterns(printProgress bool, jobs int) {
 
 		floor := NewPlane()
 		// floor.Material.Color = NewColor(1, 0.9, 0.9)
-		// floor.Material.Specular = 0
+		// floor.Material.Specular = NewColor(0, 0, 0)
 		floor.Material.Pattern = NewCheckerPattern(Colors["White"], Colors["Red"])
 
 		midSphere := NewSphere()
 		midSphere.SetTransform(NewTranslation(-0.5, 1, 0.5))
 		// midSphere.Material.Color = NewColor(0.1, 1, 0.5)
-		// midSphere.Material.Diffuse = 0.7
-		// midSphere.Material.Specular = 0.3
+		// midSphere.Material.Diffuse = NewColor(0.7, 0.7, 0.7)
+		// midSphere.Material.Specular = NewColor(0.3, 0,3 0.3)
 		midSphere.Material.Pattern = NewStripePattern(Colors["Green"], Colors["Purple"])
 
 		rightSphere := NewSphere()
 		rightSphere.SetTransform(NewTranslation(1.5, 0.5, -0.5))
 		rightSphere.SetTransform(rightSphere.Transform.Multiply(NewScale(0.5, 0.5, 0.5)))
 		// rightSphere.Material.Color = NewColor(0.5, 1, 0.1)
-		// rightSphere.Material.Diffuse = 0.7
-		// rightSphere.Material.Specular = 0.3
+		// rightSphere.Material.Diffuse = NewColor(0.7, 0.7, 0.7)
+		// rightSphere.Material.Specular = NewColor(0.3, 0.3, 0.3)
 		rightSphere.Material.Pattern = NewRingPattern(Colors["Red"], Colors["White"])
 		rightSphere.Material.Pattern.SetTransform(NewScale(0.23, 0.23, 0.23))
 
@@ -45,8 +45,8 @@ func RunDrawWorldWithMultiplePatterns(printProgress bool, jobs int) {
 		leftSphere.Material.Pattern = NewCheckerPattern(Colors["White"], Colors["Black"])
 		// leftSphere.Material.Pattern.SetTransform(NewScale(0.01, 0.01, 0.01))
 		leftSphere.Material.Color = NewColor(1, 0.8, 0.1)
-		leftSphere.Material.Diffuse = 0.7
-		leftSphere.Material.Specular = 0.3
+		leftSphere.Material.Diffuse = NewColor(0.7, 0.7, 0.7)
+		leftSphere.Material.Specular = NewColor(0.3, 0.3, 0.3)
 
 		world.Objects = []*Shape{
 			floor,

--- a/examples/draw_world_with_pattern.go
+++ b/examples/draw_world_with_pattern.go
@@ -20,22 +20,22 @@ func RunDrawWorldWithPatterns(printProgress bool, jobs int) {
 
 		floor := NewPlane()
 		floor.Material.Color = NewColor(1, 0.9, 0.9)
-		floor.Material.Specular = 0
+		floor.Material.Specular = NewColor(0, 0, 0)
 		floor.Material.Pattern = NewStripePattern(Colors["White"], Colors["Red"])
 
 		midSphere := NewSphere()
 		midSphere.SetTransform(NewTranslation(-0.5, 1, 0.5))
 		midSphere.Material.Color = NewColor(0.1, 1, 0.5)
-		midSphere.Material.Diffuse = 0.7
-		midSphere.Material.Specular = 0.3
+		midSphere.Material.Diffuse = NewColor(0.7, 0.7, 0.7)
+		midSphere.Material.Specular = NewColor(0.3, 0.3, 0.3)
 		midSphere.Material.Pattern = NewStripePattern(Colors["Green"], Colors["Purple"])
 
 		rightSphere := NewSphere()
 		rightSphere.SetTransform(NewTranslation(1.5, 0.5, -0.5))
 		rightSphere.SetTransform(rightSphere.Transform.Multiply(NewScale(0.5, 0.5, 0.5)))
 		rightSphere.Material.Color = NewColor(0.5, 1, 0.1)
-		rightSphere.Material.Diffuse = 0.7
-		rightSphere.Material.Specular = 0.3
+		rightSphere.Material.Diffuse = NewColor(0.7, 0.7, 0.7)
+		rightSphere.Material.Specular = NewColor(0.3, 0.3, 0.3)
 		rightSphere.Material.Pattern = NewStripePattern(Colors["Red"], Colors["Orange"])
 		rightSphere.Material.Pattern.SetTransform(NewScale(0.33, 0.33, 0.33))
 
@@ -45,8 +45,8 @@ func RunDrawWorldWithPatterns(printProgress bool, jobs int) {
 		leftSphere.Material.Pattern = NewStripePattern(Colors["White"], Colors["Black"])
 		leftSphere.Material.Pattern.SetTransform(NewScale(0.01, 0.01, 0.01))
 		leftSphere.Material.Color = NewColor(1, 0.8, 0.1)
-		leftSphere.Material.Diffuse = 0.7
-		leftSphere.Material.Specular = 0.3
+		leftSphere.Material.Diffuse = NewColor(0.7, 0.7, 0.7)
+		leftSphere.Material.Specular = NewColor(0.3, 0.3, 0.3)
 
 		world.Objects = []*Shape{
 			floor,

--- a/examples/draw_world_with_plane.go
+++ b/examples/draw_world_with_plane.go
@@ -19,27 +19,27 @@ func RunDrawWorldWithPlane(printProgress bool, jobs int) {
 
 		floor := NewPlane()
 		floor.Material.Color = NewColor(1, 0.9, 0.9)
-		floor.Material.Specular = 0
+		floor.Material.Specular = NewColor(0, 0, 0)
 
 		midSphere := NewSphere()
 		midSphere.SetTransform(NewTranslation(-0.5, 1, 0.5))
 		midSphere.Material.Color = NewColor(0.1, 1, 0.5)
-		midSphere.Material.Diffuse = 0.7
-		midSphere.Material.Specular = 0.3
+		midSphere.Material.Diffuse = NewColor(0.7, 0.7, 0.7)
+		midSphere.Material.Specular = NewColor(0.3, 0.3, 0.3)
 
 		rightSphere := NewSphere()
 		rightSphere.SetTransform(NewTranslation(1.5, 0.5, -0.5))
 		rightSphere.SetTransform(rightSphere.Transform.Multiply(NewScale(0.5, 0.5, 0.5)))
 		rightSphere.Material.Color = NewColor(0.5, 1, 0.1)
-		rightSphere.Material.Diffuse = 0.7
-		rightSphere.Material.Specular = 0.3
+		rightSphere.Material.Diffuse = NewColor(0.7, 0.7, 0.7)
+		rightSphere.Material.Specular = NewColor(0.3, 0.3, 0.3)
 
 		leftSphere := NewSphere()
 		leftSphere.SetTransform(NewTranslation(-1.5, 0.33, -0.75))
 		leftSphere.SetTransform(leftSphere.Transform.Multiply(NewScale(0.33, 0.33, 0.33)))
 		leftSphere.Material.Color = NewColor(1, 0.8, 0.1)
-		leftSphere.Material.Diffuse = 0.7
-		leftSphere.Material.Specular = 0.3
+		leftSphere.Material.Diffuse = NewColor(0.7, 0.7, 0.7)
+		leftSphere.Material.Specular = NewColor(0.3, 0.3, 0.3)
 
 		world.Objects = []*Shape{
 			floor,

--- a/examples/draw_world_with_snowman.go
+++ b/examples/draw_world_with_snowman.go
@@ -19,9 +19,9 @@ func RunDrawWorldWithSnowman(printProgress bool, jobs int) {
 		))
 
 		snowMaterial := DefaultMaterial()
-		snowMaterial.Specular = 0.1
-		snowMaterial.Diffuse = 0.8
-		snowMaterial.Ambient = 0.4
+		snowMaterial.Specular = NewColor(0.1, 0.1, 0.1)
+		snowMaterial.Diffuse = NewColor(0.8, 0.8, 0.8)
+		snowMaterial.Ambient = NewColor(0.4, 0.4, 0.4)
 
 		floor := NewPlane()
 		floor.Material = snowMaterial
@@ -55,9 +55,9 @@ func RunDrawWorldWithSnowman(printProgress bool, jobs int) {
 
 			hatMaterial := DefaultMaterial()
 			hatMaterial.Color = NewColor(0.1, 0.1, 0.3)
-			hatMaterial.Ambient = 0.4
-			hatMaterial.Specular = 0.3
-			hatMaterial.Diffuse = 0.3
+			hatMaterial.Ambient = NewColor(0.4, 0.4, 0.4)
+			hatMaterial.Specular = NewColor(0.3, 0.3, 0.3)
+			hatMaterial.Diffuse = NewColor(0.3, 0.3, 0.3)
 
 			topOne := NewCone()
 			topOne.Material = hatMaterial
@@ -80,8 +80,8 @@ func RunDrawWorldWithSnowman(printProgress bool, jobs int) {
 
 			band := NewCylinder()
 			band.Material.Color = NewColor(0.7, 0, 0)
-			band.Material.Specular = 0.75
-			band.Material.Ambient = 0.50
+			band.Material.Specular = NewColor(0.75, 0.75, 0.75)
+			band.Material.Ambient = NewColor(0.5, 0.5, 0.5)
 			band.Material.RefractiveIndex = 0.5
 			band.Material.Reflective = 0.5
 			band.SetTransform(band.Transform.Compose(
@@ -135,7 +135,7 @@ func RunDrawWorldWithSnowman(printProgress bool, jobs int) {
 		createDot := func() *Shape {
 			sphere := NewSphere()
 			sphere.Shadows = false
-			sphere.Material.Specular = 0.2
+			sphere.Material.Specular = NewColor(0.2, 0.2, 0.2)
 			sphere.Material.Color = NewColor(0.1, 0.1, 0.1)
 			sphere.SetTransform(sphere.Transform.Compose(
 				NewScale(0.05, 0.05, 0.05),

--- a/examples/draw_world_with_sphere_and_area_light.go
+++ b/examples/draw_world_with_sphere_and_area_light.go
@@ -20,12 +20,12 @@ func RunDrawWorldWithSphereAndAreaLight(printProgress bool, jobs int) {
 
 		floor := NewPlane()
 		floor.Material.Color = NewColor(1, 0.9, 0.9)
-		floor.Material.Specular = 0
+		floor.Material.Specular = NewColor(0, 0, 0)
 
 		sphere := NewSphere()
-		sphere.Material.Ambient = 0.1
-		sphere.Material.Diffuse = 0.6
-		sphere.Material.Specular = 0.0
+		sphere.Material.Ambient = NewColor(0.1, 0.1, 0.1)
+		sphere.Material.Diffuse = NewColor(0.6, 0.6, 0.6)
+		sphere.Material.Specular = NewColor(0, 0, 0)
 		sphere.Material.Reflective = 0.3
 		sphere.Material.Color = Colors["DarkGreen"]
 		sphere.SetTransform(sphere.Transform.Compose(
@@ -33,9 +33,9 @@ func RunDrawWorldWithSphereAndAreaLight(printProgress bool, jobs int) {
 		))
 
 		cube := NewCube()
-		cube.Material.Ambient = 0.1
-		cube.Material.Diffuse = 0.6
-		cube.Material.Specular = 0.0
+		cube.Material.Ambient = NewColor(0.1, 0.1, 0.1)
+		cube.Material.Diffuse = NewColor(0.6, 0.6, 0.6)
+		cube.Material.Specular = NewColor(0, 0, 0)
 		cube.Material.Reflective = 0.3
 		cube.Material.Color = Colors["DarkRed"]
 		cube.SetTransform(cube.Transform.Compose(
@@ -47,9 +47,9 @@ func RunDrawWorldWithSphereAndAreaLight(printProgress bool, jobs int) {
 		cylinder.LocalShape.(*Cylinder).Minimum = 0
 		cylinder.LocalShape.(*Cylinder).Maximum = 2
 		cylinder.Material.Color = Colors["DarkBlue"]
-		cylinder.Material.Ambient = 0.6
-		cylinder.Material.Diffuse = 0.6
-		cylinder.Material.Specular = 0.0
+		cylinder.Material.Ambient = NewColor(0.6, 0.6, 0.6)
+		cylinder.Material.Diffuse = NewColor(0.6, 0.6, 0.6)
+		cylinder.Material.Specular = NewColor(0.0, 0.0, 0.0)
 		cylinder.Material.Reflective = 0.3
 		cylinder.SetTransform(cylinder.Transform.Compose(
 			NewTranslation(4, 0, 5),

--- a/examples/draw_world_with_table.go
+++ b/examples/draw_world_with_table.go
@@ -30,9 +30,9 @@ func RunDrawWorldWithTable(printProgress bool, jobs int) {
 			NewColor(0.25, 0.25, 0.25),
 		)
 		floorCeiling.Material.Pattern.SetTransform(floorCeiling.Material.Pattern.Transform.Multiply(NewUScale(0.07)))
-		floorCeiling.Material.Ambient = 0.25
-		floorCeiling.Material.Diffuse = 0.7
-		floorCeiling.Material.Specular = 0.9
+		floorCeiling.Material.Ambient = NewColor(0.25, 0.25, 0.25)
+		floorCeiling.Material.Diffuse = NewColor(0.7, 0.7, 0.7)
+		floorCeiling.Material.Specular = NewColor(0.9, 0.9, 0.9)
 		floorCeiling.Material.Shininess = 300
 		floorCeiling.Material.Reflective = 0.1
 
@@ -43,9 +43,9 @@ func RunDrawWorldWithTable(printProgress bool, jobs int) {
 			NewColor(0.3725, 0.2902, 0.2275),
 		)
 		walls.Material.Pattern.SetTransform(walls.Material.Pattern.Transform.Multiply(NewScale(0.05, 20, 0.05)))
-		walls.Material.Ambient = 0.1
-		walls.Material.Diffuse = 0.7
-		walls.Material.Specular = 0.9
+		walls.Material.Ambient = NewColor(0.1, 0.1, 0.1)
+		walls.Material.Diffuse = NewColor(0.7, 0.7, 0.7)
+		walls.Material.Specular = NewColor(0.9, 0.9, 0.9)
 		walls.Material.Shininess = 300
 		walls.Material.Reflective = 0.1
 		walls.Material.Pattern.SetTransform(NewScale(0.05, 20, 0.05))
@@ -54,16 +54,16 @@ func RunDrawWorldWithTable(printProgress bool, jobs int) {
 		tabletop.SetTransform(tabletop.Transform.Compose(NewScale(3, 0.1, 2), NewTranslation(0, 3.1, 0)))
 		tabletop.Material.Pattern = NewStripePattern(NewColor(0.5529, 0.4235, 0.3255), NewColor(0.6588, 0.5098, 0.4000))
 		tabletop.Material.Pattern.SetTransform(tabletop.Material.Pattern.Transform.Compose(NewRotateY(0.1), NewScale(0.05, 0.05, 0.05)))
-		tabletop.Material.Ambient = 0.1
-		tabletop.Material.Diffuse = 0.7
-		tabletop.Material.Specular = 0.9
+		tabletop.Material.Ambient = NewColor(0.1, 0.1, 0.1)
+		tabletop.Material.Diffuse = NewColor(0.7, 0.7, 0.7)
+		tabletop.Material.Specular = NewColor(0.9, 0.9, 0.9)
 		tabletop.Material.Shininess = 300
 		tabletop.Material.Reflective = 0.2
 
 		legMaterial := DefaultMaterial()
 		legMaterial.Color = NewColor(0.5529, 0.4235, 0.3255)
-		legMaterial.Ambient = 0.2
-		legMaterial.Diffuse = 0.7
+		legMaterial.Ambient = NewColor(0.2, 0.2, 0.2)
+		legMaterial.Diffuse = NewColor(0.7, 0.7, 0.7)
 
 		leg1 := NewCube()
 		leg1.SetTransform(leg1.Transform.Compose(NewScale(0.1, 1.5, 0.1), NewTranslation(2.7, 1.5, -1.7)))
@@ -84,9 +84,9 @@ func RunDrawWorldWithTable(printProgress bool, jobs int) {
 		glassCube := NewCube()
 		glassCube.SetTransform(glassCube.Transform.Compose(NewUScale(0.25), NewRotateY(0.2), NewTranslation(0, 3.450001, 0)))
 		glassCube.Material.Color = NewColor(1, 1, 0.8)
-		glassCube.Material.Diffuse = 0.3
-		glassCube.Material.Ambient = 0
-		glassCube.Material.Specular = 0.9
+		glassCube.Material.Diffuse = NewColor(0.3, 0.3, 0.3)
+		glassCube.Material.Ambient = NewColor(0, 0, 0)
+		glassCube.Material.Specular = NewColor(0.9, 0.9, 0.9)
 		glassCube.Material.Shininess = 300
 		glassCube.Material.Reflective = 0.7
 		glassCube.Material.Transparency = 0.7
@@ -95,7 +95,7 @@ func RunDrawWorldWithTable(printProgress bool, jobs int) {
 		littleCube1 := NewCube()
 		littleCube1.SetTransform(littleCube1.Transform.Compose(NewUScale(0.15), NewRotateY(-0.4), NewTranslation(1, 3.35, -0.9)))
 		littleCube1.Material.Color = NewColor(1, 0.5, 0.5)
-		littleCube1.Material.Diffuse = 0.4
+		littleCube1.Material.Diffuse = NewColor(0.4, 0.4, 0.4)
 		littleCube1.Material.Reflective = 0.6
 
 		littleCube2 := NewCube()
@@ -117,29 +117,29 @@ func RunDrawWorldWithTable(printProgress bool, jobs int) {
 		frame1 := NewCube()
 		frame1.SetTransform(frame1.Transform.Compose(NewScale(0.05, 1, 1), NewTranslation(-10, 4, 1)))
 		frame1.Material.Color = NewColor(0.7098, 0.2471, 0.2196)
-		frame1.Material.Diffuse = 0.6
+		frame1.Material.Diffuse = NewColor(0.6, 0.6, 0.6)
 
 		frame2 := NewCube()
 		frame2.SetTransform(frame2.Transform.Compose(NewScale(0.05, 0.4, 0.4), NewTranslation(-10, 3.4, 2.7)))
 		frame2.Material.Color = NewColor(0.2667, 0.2706, 0.6902)
-		frame2.Material.Diffuse = 0.6
+		frame2.Material.Diffuse = NewColor(0.6, 0.6, 0.6)
 
 		frame3 := NewCube()
 		frame3.SetTransform(frame3.Transform.Compose(NewScale(0.05, 0.4, 0.4), NewTranslation(-10, 4.6, 2.7)))
 		frame3.Material.Color = NewColor(0.3098, 0.5961, 0.3098)
-		frame3.Material.Diffuse = 0.6
+		frame3.Material.Diffuse = NewColor(0.6, 0.6, 0.6)
 
 		mirrorFrame := NewCube()
 		mirrorFrame.SetTransform(mirrorFrame.Transform.Compose(NewScale(5, 1.5, 0.05), NewTranslation(-2, 3.5, 9.95)))
 		mirrorFrame.Material.Color = NewColor(0.3882, 0.2627, 0.1882)
-		mirrorFrame.Material.Diffuse = 0.7
+		mirrorFrame.Material.Diffuse = NewColor(0.7, 0.7, 0.7)
 
 		mirror := NewCube()
 		mirror.SetTransform(mirror.Transform.Compose(NewScale(4.8, 1.4, 0.06), NewTranslation(-2, 3.5, 9.95)))
 		mirror.Material.Color = Colors["Black"]
-		mirror.Material.Ambient = 0
-		mirror.Material.Diffuse = 0
-		mirror.Material.Specular = 1
+		mirror.Material.Ambient = NewColor(0, 0, 0)
+		mirror.Material.Diffuse = NewColor(0, 0, 0)
+		mirror.Material.Specular = NewColor(1, 1, 1)
 		mirror.Material.Shininess = 300
 		mirror.Material.Reflective = 1
 

--- a/examples/draw_world_with_triangles.go
+++ b/examples/draw_world_with_triangles.go
@@ -22,22 +22,22 @@ func RunDrawWorldWithTriangles(printProgress bool, jobs int) {
 			bottom := NewTriangle(NewPoint(-1, 0, 0), NewPoint(0, 0, 1), NewPoint(1, 0, 0))
 			bottom.Material.Color = Colors["White"]
 			bottom.Material.Reflective = 0.8
-			bottom.Material.Ambient = 0.5
+			bottom.Material.Ambient = NewColor(0.5, 0.5, 0.5)
 			bottom.Material.Transparency = 0.9
 			side1 := NewTriangle(NewPoint(-1, 0, 0), NewPoint(0, 0, 1), NewPoint(0, 1, 0))
 			side1.Material.Color = Colors["Green"]
 			side1.Material.Reflective = 0.8
-			side1.Material.Ambient = 0.5
+			side1.Material.Ambient = NewColor(0.5, 0.5, 0.5)
 			side1.Material.Transparency = 0.9
 			side2 := NewTriangle(NewPoint(0, 1, 0), NewPoint(0, 0, 1), NewPoint(1, 0, 0))
 			side2.Material.Color = Colors["Blue"]
 			side2.Material.Reflective = 0.8
-			side2.Material.Ambient = 0.5
+			side2.Material.Ambient = NewColor(0.5, 0.5, 0.5)
 			side2.Material.Transparency = 0.9
 			side3 := NewTriangle(NewPoint(-1, 0, 0), NewPoint(0, 1, 0), NewPoint(1, 0, 0))
 			side3.Material.Color = Colors["Red"]
 			side3.Material.Reflective = 0.8
-			side3.Material.Ambient = 0.5
+			side3.Material.Ambient = NewColor(0.5, 0.5, 0.5)
 			side3.Material.Transparency = 0.9
 			g := NewGroup()
 			g.AddChildren(side1, side2, side3, bottom)

--- a/examples/draw_world_with_uv_pattern.go
+++ b/examples/draw_world_with_uv_pattern.go
@@ -34,8 +34,8 @@ func RunDrawWorldWithUVPattern(printProgress bool, jobs int) {
 		sphere := NewSphere()
 		sphere.SetTransform(NewTranslation(3, 1, 0))
 		sphere.Material.Color = NewColor(0.1, 1, 0.5)
-		sphere.Material.Diffuse = 0.7
-		sphere.Material.Specular = 0.3
+		sphere.Material.Diffuse = NewColor(0.7, 0.7, 0.7)
+		sphere.Material.Specular = NewColor(0.3, 0.3, 0.3)
 		sphere.Material.Pattern = NewTextureMapPattern(
 			NewUVCheckerPattern(16, 16, Colors["Green"], Colors["Purple"]),
 			SphericalMap,
@@ -43,8 +43,8 @@ func RunDrawWorldWithUVPattern(printProgress bool, jobs int) {
 
 		cube := NewCube()
 		cube.SetTransform(NewTranslation(0, 1, 0))
-		cube.Material.Diffuse = 0.7
-		cube.Material.Specular = 0.3
+		cube.Material.Diffuse = NewColor(0.7, 0.7, 0.7)
+		cube.Material.Specular = NewColor(0.3, 0.3, 0.3)
 		cube.Material.Pattern = NewTextureMapPattern(
 			NewUVCheckerPattern(16, 16, Colors["Green"], Colors["Purple"]),
 			SphericalMap,
@@ -59,8 +59,8 @@ func RunDrawWorldWithUVPattern(printProgress bool, jobs int) {
 			NewTranslation(5, 1, 0),
 			NewScale(1, 2, 1),
 		))
-		cone.Material.Diffuse = 0.7
-		cone.Material.Specular = 0.3
+		cone.Material.Diffuse = NewColor(0.7, 0.7, 0.7)
+		cone.Material.Specular = NewColor(0.3, 0.3, 0.3)
 		cone.Material.Pattern = NewTextureMapPattern(
 			NewUVCheckerPattern(16, 16, Colors["Green"], Colors["Purple"]),
 			SphericalMap,
@@ -70,8 +70,8 @@ func RunDrawWorldWithUVPattern(printProgress bool, jobs int) {
 		cyl.LocalShape.(*Cylinder).Closed = true
 		cyl.LocalShape.(*Cylinder).Minimum = 0
 		cyl.LocalShape.(*Cylinder).Maximum = 1
-		cyl.Material.Diffuse = 0.7
-		cyl.Material.Specular = 0.3
+		cyl.Material.Diffuse = NewColor(0.7, 0.7, 0.7)
+		cyl.Material.Specular = NewColor(0.3, 0.3, 0.3)
 		cyl.Material.Pattern = NewTextureMapPattern(
 			NewUVCheckerPattern(16, 16, Colors["Green"], Colors["Purple"]),
 			CylindricalMap,

--- a/raytracer/integration_test.go
+++ b/raytracer/integration_test.go
@@ -36,7 +36,7 @@ func renderIntegrationTestScene(jobs int) {
 
 	floor := NewPlane()
 	floor.Material.Color = NewColor(1, 0.9, 0.9)
-	floor.Material.Specular = 0
+	floor.Material.Specular = NewColor(0, 0, 0)
 
 	sphere := NewSphere()
 	sphere.Material.Color = Colors["Red"]

--- a/raytracer/material.go
+++ b/raytracer/material.go
@@ -8,9 +8,9 @@ import (
 type Material struct {
 	Label           string
 	Color           Color
-	Ambient         float64
-	Diffuse         float64
-	Specular        float64
+	Ambient         Color
+	Diffuse         Color
+	Specular        Color
 	Shininess       float64
 	Pattern         *Pattern
 	Reflective      float64
@@ -23,9 +23,9 @@ func DefaultMaterial() *Material {
 	return &Material{
 		Label:           "default-material",
 		Color:           Colors["White"],
-		Ambient:         0.1,
-		Diffuse:         0.9,
-		Specular:        0.9,
+		Ambient:         NewColor(0.1, 0.1, 0.1),
+		Diffuse:         NewColor(0.9, 0.9, 0.9),
+		Specular:        NewColor(0.9, 0.9, 0.9),
 		Shininess:       200,
 		Reflective:      0.0,
 		Transparency:    0.0,
@@ -37,11 +37,11 @@ func (m *Material) IsEqualTo(m2 *Material) bool {
 	// TODO add check for Pattern equality too
 	if !m.Color.IsEqualTo(m2.Color) {
 		return false
-	} else if m.Ambient != m2.Ambient {
+	} else if !m.Ambient.IsEqualTo(m2.Ambient) {
 		return false
-	} else if m.Diffuse != m2.Diffuse {
+	} else if !m.Diffuse.IsEqualTo(m2.Diffuse) {
 		return false
-	} else if m.Specular != m2.Specular {
+	} else if !m.Specular.IsEqualTo(m2.Specular) {
 		return false
 	} else if m.Shininess != m2.Shininess {
 		return false
@@ -88,7 +88,7 @@ func (m *Material) Lighting(obj *Shape, light *AreaLight, point Tuple, eyeVector
 	}
 
 	effectiveColor := baseColor.MultiplyColor(light.GetIntensity()) // Combine the surface color with the light's color/intensity
-	ambient = effectiveColor.Multiply(m.Ambient)                    // Compute the ambient contribution
+	ambient = effectiveColor.MultiplyColor(m.Ambient)               // Compute the ambient contribution
 
 	samples := []Tuple{}
 	// TODO: can we memoize and abstract this out, with the shared code in IntensityAt()?
@@ -112,7 +112,7 @@ func (m *Material) Lighting(obj *Shape, light *AreaLight, point Tuple, eyeVector
 		}
 
 		// Compute the diffuse contribution
-		diffuse = effectiveColor.Multiply(m.Diffuse).Multiply(lightDotNormal)
+		diffuse = effectiveColor.MultiplyColor(m.Diffuse).Multiply(lightDotNormal)
 		sum = sum.Add(diffuse)
 
 		// Compute the specular contribution
@@ -120,7 +120,7 @@ func (m *Material) Lighting(obj *Shape, light *AreaLight, point Tuple, eyeVector
 		reflectDotEye := reflectVector.Dot(eyeVector) // The cosine of angle between reflection vector + eye vector (nenative means light reflects away from eye)
 		if reflectDotEye > 0 {
 			factor := math.Pow(reflectDotEye, m.Shininess)
-			specular = light.GetIntensity().Multiply(m.Specular).Multiply(factor)
+			specular = light.GetIntensity().MultiplyColor(m.Specular).Multiply(factor)
 			sum = sum.Add(specular)
 		}
 	}

--- a/raytracer/material_test.go
+++ b/raytracer/material_test.go
@@ -10,9 +10,9 @@ func TestDefaultMaterial(t *testing.T) {
 	m := DefaultMaterial()
 
 	assertEqualColor(t, Colors["White"], m.Color)
-	assertEqualFloat64(t, 0.1, m.Ambient)
-	assertEqualFloat64(t, 0.9, m.Diffuse)
-	assertEqualFloat64(t, 0.9, m.Specular)
+	assertEqualColor(t, NewColor(0.1, 0.1, 0.1), m.Ambient)
+	assertEqualColor(t, NewColor(0.9, 0.9, 0.9), m.Diffuse)
+	assertEqualColor(t, NewColor(0.9, 0.9, 0.9), m.Specular)
 	assertEqualFloat64(t, 200, m.Shininess)
 }
 
@@ -153,9 +153,9 @@ func TestLightingWithAPatternApplied(t *testing.T) {
 	obj := NewSphere()
 	mat := DefaultMaterial()
 	mat.Pattern = NewStripePattern(Colors["White"], Colors["Black"])
-	mat.Ambient = 1
-	mat.Diffuse = 0
-	mat.Specular = 0
+	mat.Ambient = NewColor(1, 1, 1)
+	mat.Diffuse = NewColor(0, 0, 0)
+	mat.Specular = NewColor(0, 0, 0)
 	eyeV := NewVector(0, 0, -1)
 	normalV := NewVector(0, 0, -1)
 	light := NewPointLight(NewPoint(0, 0, -10), Colors["White"])
@@ -184,9 +184,9 @@ func TestLightingUsesLightIntensityToAttentuateColor(t *testing.T) {
 	w := DefaultWorld()
 	w.Lights[0] = NewPointLight(NewPoint(0, 0, -10), NewColor(1, 1, 1))
 	s := w.Objects[0]
-	s.Material.Ambient = 0.1
-	s.Material.Diffuse = 0.9
-	s.Material.Specular = 0
+	s.Material.Ambient = NewColor(0.1, 0.1, 0.1)
+	s.Material.Diffuse = NewColor(0.9, 0.9, 0.9)
+	s.Material.Specular = NewColor(0, 0, 0)
 	s.Material.Color = NewColor(1, 1, 1)
 	pt := NewPoint(0, 0, -1)
 	eyeV := NewVector(0, 0, -1)
@@ -211,9 +211,9 @@ func TestLightingUsesLightIntensityToAttentuateColor(t *testing.T) {
 func TestLightingSamplesTheAreaLight(t *testing.T) {
 	light := NewAreaLight(NewPoint(-0.5, -0.5, -5), NewVector(1, 0, 0), 2, NewVector(0, 1, 0), 2, NewColor(1, 1, 1))
 	shape := NewSphere()
-	shape.Material.Ambient = 0.1
-	shape.Material.Diffuse = 0.9
-	shape.Material.Specular = 0
+	shape.Material.Ambient = NewColor(0.1, 0.1, 0.1)
+	shape.Material.Diffuse = NewColor(0.9, 0.9, 0.9)
+	shape.Material.Specular = NewColor(0, 0, 0)
 	shape.Material.Color = NewColor(1, 1, 1)
 	eye := NewPoint(0, 0, -5)
 	testCases := []struct {

--- a/raytracer/shape_test.go
+++ b/raytracer/shape_test.go
@@ -28,7 +28,7 @@ func TestDefaultMatrial(t *testing.T) {
 func TestAssigningAMaterial(t *testing.T) {
 	s := NewTestShape()
 	m := DefaultMaterial()
-	m.Ambient = 1
+	m.Ambient = NewColor(1, 1, 1)
 	s.Material = m
 
 	assertEqualMaterial(t, *s.Material, *m)

--- a/raytracer/world.go
+++ b/raytracer/world.go
@@ -29,8 +29,8 @@ func DefaultWorld() *World {
 	defaultPointLight := NewPointLight(NewPoint(-10, 10, -10), Colors["White"])
 	defaultObj1 := NewSphere()
 	defaultObj1.Material.Color = NewColor(0.8, 1.0, 0.6)
-	defaultObj1.Material.Diffuse = 0.7
-	defaultObj1.Material.Specular = 0.2
+	defaultObj1.Material.Diffuse = NewColor(0.7, 0.7, 0.7)
+	defaultObj1.Material.Specular = NewColor(0.2, 0.2, 0.2)
 
 	defaultObj2 := NewSphere()
 	defaultObj2.SetTransform(NewScale(0.5, 0.5, 0.5))

--- a/raytracer/world_test.go
+++ b/raytracer/world_test.go
@@ -21,9 +21,9 @@ func TestDefaultWorld(t *testing.T) {
 	s1 := NewSphere()
 	s1.Material = &Material{
 		Color:           NewColor(0.8, 1.0, 0.6),
-		Ambient:         0.1,
-		Diffuse:         0.7,
-		Specular:        0.2,
+		Ambient:         NewColor(0.1, 0.1, 0.1),
+		Diffuse:         NewColor(0.7, 0.7, 0.7),
+		Specular:        NewColor(0.2, 0.2, 0.2),
 		Shininess:       200,
 		Reflective:      0.0,
 		Transparency:    0.0,
@@ -125,8 +125,8 @@ func TestColorAtWhenRayHitsOuterSphere(t *testing.T) {
 // Ray is inside outer sphere, pointed at inner sphere.
 func TestColorAtWithAnIntersectionBehindRay(t *testing.T) {
 	w := DefaultWorld()
-	w.Objects[0].Material.Ambient = 1 // outer
-	w.Objects[1].Material.Ambient = 1 // inner
+	w.Objects[0].Material.Ambient = NewColor(1, 1, 1) // outer
+	w.Objects[1].Material.Ambient = NewColor(1, 1, 1) // inner
 	r := NewRay(NewPoint(0, 0, 0.75), NewVector(0, 0, -1))
 	actual := w.ColorAt(r, DefaultMaximumReflections)
 	expected := w.Objects[1].Material.Color
@@ -173,7 +173,7 @@ func TestTheRefractedColorUnderTotalInternalReflection(t *testing.T) {
 
 func TestTheRefractedColorWithARefractedRay(t *testing.T) {
 	w := DefaultWorld()
-	w.Objects[0].Material.Ambient = 1.0
+	w.Objects[0].Material.Ambient = NewColor(1.0, 1.0, 1.0)
 	w.Objects[0].Material.Pattern = NewTestPattern()
 	w.Objects[1].Material.Transparency = 1.0
 	w.Objects[1].Material.RefractiveIndex = 1.5
@@ -200,7 +200,7 @@ func TestShadeHitWithATransparentMaterial(t *testing.T) {
 	ball := NewSphere()
 	ball.SetTransform(NewTranslation(0, -3.5, -0.5))
 	ball.Material.Color = NewColor(1, 0, 0)
-	ball.Material.Ambient = 0.5
+	ball.Material.Ambient = NewColor(0.5, 0.5, 0.5)
 	w.Objects = append(w.Objects, floor, ball)
 	r := NewRay(NewPoint(0, 0, -3), NewVector(0, -math.Sqrt(2)/2, math.Sqrt(2)/2))
 	xs := Intersections{NewIntersection(math.Sqrt(2), floor)}
@@ -221,7 +221,7 @@ func TestShadeHitWithAReflectiveTransparentMaterial(t *testing.T) {
 	ball := NewSphere()
 	ball.SetTransform(NewTranslation(0, -3.5, -0.5))
 	ball.Material.Color = NewColor(1, 0, 0)
-	ball.Material.Ambient = 0.5
+	ball.Material.Ambient = NewColor(0.5, 0.5, 0.5)
 	w.Objects = append(w.Objects, floor, ball)
 	r := NewRay(NewPoint(0, 0, -3), NewVector(0, -math.Sqrt(2)/2, math.Sqrt(2)/2))
 	xs := Intersections{NewIntersection(math.Sqrt(2), floor)}
@@ -289,7 +289,7 @@ func BenchmarkWorldMethodColorAt(b *testing.B) {
 func BenchmarkWorldMethodRefractedColor(b *testing.B) {
 	// Taken from TestTheRefractedColorWithARefractedRay, so this does return a color.
 	w := DefaultWorld()
-	w.Objects[0].Material.Ambient = 1.0
+	w.Objects[0].Material.Ambient = NewColor(1.0, 1.0, 1.0)
 	w.Objects[0].Material.Pattern = NewTestPattern()
 	w.Objects[1].Material.Transparency = 1.0
 	w.Objects[1].Material.RefractiveIndex = 1.5

--- a/raytracer/yaml_scene_file.go
+++ b/raytracer/yaml_scene_file.go
@@ -218,13 +218,13 @@ func decodeMaterial(defs map[string]Material, m Material, n yaml.Node) (Material
 			m.Color = NewColor(r, g, b)
 		}
 		if v.Diffuse != nil {
-			m.Diffuse = *v.Diffuse
+			m.Diffuse = NewColor(*v.Diffuse, *v.Diffuse, *v.Diffuse)
 		}
 		if v.Ambient != nil {
-			m.Ambient = *v.Ambient
+			m.Ambient = NewColor(*v.Ambient, *v.Ambient, *v.Ambient)
 		}
 		if v.Specular != nil {
-			m.Specular = *v.Specular
+			m.Specular = NewColor(*v.Specular, *v.Specular, *v.Specular)
 		}
 		if v.Reflective != nil {
 			m.Reflective = *v.Reflective


### PR DESCRIPTION
This adds more variability to Material phong shading, and sets the stage for .mtl parsing, since it prints these values as RGB instead of floats.

Performance mostly unchanged, although we should look for Material.IsEqualTo() speedups in the future:

<img width="1143" alt="Screen Shot 2022-06-25 at 9 58 43 PM" src="https://user-images.githubusercontent.com/5054/175800098-778f8583-8635-421e-af13-5d42f7ad72f5.png">
